### PR TITLE
Update docker.sh

### DIFF
--- a/docker.sh
+++ b/docker.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-docker container run --rm -it -v $(pwd):/full-fledged-hledger dastapov/full-fledged-hledger:latest 
+docker container run --rm -it -v "$(pwd)":/full-fledged-hledger dastapov/full-fledged-hledger:latest 

--- a/docker.sh
+++ b/docker.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-docker container run --rm -it -v "$(pwd)":/full-fledged-hledger dastapov/full-fledged-hledger:latest 
+docker container run --rm -it -v "$(pwd)":/full-fledged-hledger dastapov/full-fledged-hledger:latest

--- a/docker.sh
+++ b/docker.sh
@@ -1,2 +1,10 @@
 #!/bin/bash
-docker container run --rm -it -v "$(pwd)":/full-fledged-hledger dastapov/full-fledged-hledger:latest
+
+# check if started in WSL
+if [[ $(uname -r) =~ Microsoft$ ]]; then
+    #  if WSL
+    docker container run --rm -it -v "$(wslpath -a -m .)":/full-fledged-hledger dastapov/full-fledged-hledger:latest
+else
+    # otherwise
+    docker container run --rm -it -v "$(pwd)":/full-fledged-hledger dastapov/full-fledged-hledger:latest
+fi

--- a/docker.sh
+++ b/docker.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-docker container run --rm -it -v "$(pwd)":/full-fledged-hledger dastapov/full-fledged-hledger:latest
+docker container run --rm -it -v "$(pwd)":/full-fledged-hledger dastapov/full-fledged-hledger:latest 


### PR DESCRIPTION
To avoid problems with spaces in `${pwd}` path `"${pwd}"` used instead:

```
root@BCZWPHJAL2:/mnt/c/Users/User/OneDrive - User/Documents/GitHub/full-fledged-hledger# ./docker.sh
docker: invalid reference format.
See 'docker run --help'.
```