### PR TITLE
Fix volume definition in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN adduser --system --ingroup root hledger
 
 # This is where the data dir would be mounted to
 RUN mkdir full-fledged-hledger
-VOLUME full-fledged-hledger
+VOLUME /full-fledged-hledger
 
 ENV STACK_ROOT /root/.stack
 RUN echo "allow-different-user: true" >> /root/.stack/config.yaml


### PR DESCRIPTION
Currently, the Docker image for this project fails for the newer versions of Docker engine. This is easily reproduced by running the `docker.sh` script:

```sh
$ ./docker.sh
docker: Error response from daemon: failed to create shim: OCI runtime create failed: invalid mount {Destination:full-fledged-hledger Type:bind Source:/mnt/data/docker/volumes/bccf3f2bf031303ca4a26e92dd43e9a182059923d7a0490f0b8f9766c6531bb2/_data Options:[rbind]}: mount destination full-fledged-hledger not absolute: unknown.
```

Based on current [Dockerfile reference][dockerfile_volume], the `VOLUME` instruction must include an absolute path.

Apparently, this started failing in a newer version of Docker, as it worked correctly previously. For debugging purposes:

```sh
$ docker version
Client:
 Version:           20.10.6
 API version:       1.41
 Go version:        go1.16.3
 Git commit:        370c28948e
 Built:             Mon Apr 12 14:10:41 2021
 OS/Arch:           linux/amd64
 Context:           default
 Experimental:      true

Server:
 Engine:
  Version:          20.10.6
  API version:      1.41 (minimum version 1.12)
  Go version:       go1.16.3
  Git commit:       8728dd246c
  Built:            Mon Apr 12 14:10:25 2021
  OS/Arch:          linux/amd64
  Experimental:     false
 containerd:
  Version:          v1.5.0
  GitCommit:        8c906ff108ac28da23f69cc7b74f8e7a470d1df0.m
 runc:
  Version:          1.0.0-rc94
  GitCommit:        2c7861bc5e1b3e756392236553ec14a78a09f8bf
 docker-init:
  Version:          0.19.0
  GitCommit:        de40ad0
```

[dockerfile_volume]: https://docs.docker.com/engine/reference/builder/#volume