### PR TITLE
Do not elide amounts in generated reports

### DIFF
--- a/01-getting-started/export/export.hs
+++ b/01-getting-started/export/export.hs
@@ -97,7 +97,7 @@ main = do
 export_all flags targets = return $ Just $ do
   let first = firstYear flags
       current = currentYear flags
-      
+
   if null targets then want (reports first current) else want targets
 
   -- Discover and cache the list of all includes for the given .journal file, recursively
@@ -107,11 +107,11 @@ export_all flags targets = return $ Just $ do
 
   (transactions "//*") %> hledger_process_year flags year_inputs ["print"]
 
-  (income_expenses "//*") %> hledger_process_year flags year_inputs ["is","--flat"]
+  (income_expenses "//*") %> hledger_process_year flags year_inputs ["is","--flat","--no-elide"]
 
-  (balance_sheet "//*") %> hledger_process_year flags year_inputs ["balancesheet"]
+  (balance_sheet "//*") %> hledger_process_year flags year_inputs ["balancesheet","--no-elide"]
 
-  (cash_flow "//*") %> hledger_process_year flags year_inputs ["cashflow","not:desc:(opening balances)"]
+  (cash_flow "//*") %> hledger_process_year flags year_inputs ["cashflow","not:desc:(opening balances)","--no-elide"]
 
   (closing_balances "//*") %> generate_closing_balances flags year_inputs
 
@@ -190,10 +190,10 @@ getIncludes base file = do
                                                                    , stripPrefix "include " x]]
   return (file:includes)
 
-normalisePath base x  
+normalisePath base x
   | "/" `isPrefixOf` x = x
   | "./export/" `isPrefixOf` x, Just y <- stripPrefix "./export/" x = y
-  | otherwise = base </> x 
+  | otherwise = base </> x
 
 split s = takeWhile (/="") $ unfoldr (Just . head . lex) $ takeFileName s
 

--- a/02-getting-data-in/export/export.hs
+++ b/02-getting-data-in/export/export.hs
@@ -99,7 +99,7 @@ main = do
 export_all flags targets = return $ Just $ do
   let first = firstYear flags
       current = currentYear flags
-      
+
   if null targets then want (reports first current) else want targets
 
   -- Discover and cache the list of all includes for the given .journal file, recursively
@@ -109,11 +109,11 @@ export_all flags targets = return $ Just $ do
 
   (transactions "//*") %> hledger_process_year flags year_inputs ["print"]
 
-  (income_expenses "//*") %> hledger_process_year flags year_inputs ["is","--flat"]
+  (income_expenses "//*") %> hledger_process_year flags year_inputs ["is","--flat","--no-elide"]
 
-  (balance_sheet "//*") %> hledger_process_year flags year_inputs ["balancesheet"]
+  (balance_sheet "//*") %> hledger_process_year flags year_inputs ["balancesheet","--no-elide"]
 
-  (cash_flow "//*") %> hledger_process_year flags year_inputs ["cashflow","not:desc:(opening balances)"]
+  (cash_flow "//*") %> hledger_process_year flags year_inputs ["cashflow","not:desc:(opening balances)","--no-elide"]
 
   (closing_balances "//*") %> generate_closing_balances flags year_inputs
 
@@ -192,10 +192,10 @@ getIncludes base file = do
                                                                    , stripPrefix "include " x]]
   return (file:includes)
 
-normalisePath base x  
+normalisePath base x
   | "/" `isPrefixOf` x = x
   | "./export/" `isPrefixOf` x, Just y <- stripPrefix "./export/" x = y
-  | otherwise = base </> x 
+  | otherwise = base </> x
 
 split s = takeWhile (/="") $ unfoldr (Just . head . lex) $ takeFileName s
 

--- a/03-getting-full-history/export/export.hs
+++ b/03-getting-full-history/export/export.hs
@@ -99,7 +99,7 @@ main = do
 export_all flags targets = return $ Just $ do
   let first = firstYear flags
       current = currentYear flags
-      
+
   if null targets then want (reports first current) else want targets
 
   -- Discover and cache the list of all includes for the given .journal file, recursively
@@ -109,11 +109,11 @@ export_all flags targets = return $ Just $ do
 
   (transactions "//*") %> hledger_process_year flags year_inputs ["print"]
 
-  (income_expenses "//*") %> hledger_process_year flags year_inputs ["is","--flat"]
+  (income_expenses "//*") %> hledger_process_year flags year_inputs ["is","--flat","--no-elide"]
 
-  (balance_sheet "//*") %> hledger_process_year flags year_inputs ["balancesheet"]
+  (balance_sheet "//*") %> hledger_process_year flags year_inputs ["balancesheet","--no-elide"]
 
-  (cash_flow "//*") %> hledger_process_year flags year_inputs ["cashflow","not:desc:(opening balances)"]
+  (cash_flow "//*") %> hledger_process_year flags year_inputs ["cashflow","not:desc:(opening balances)","--no-elide"]
 
   (closing_balances "//*") %> generate_closing_balances flags year_inputs
 
@@ -192,10 +192,10 @@ getIncludes base file = do
                                                                    , stripPrefix "include " x]]
   return (file:includes)
 
-normalisePath base x  
+normalisePath base x
   | "/" `isPrefixOf` x = x
   | "./export/" `isPrefixOf` x, Just y <- stripPrefix "./export/" x = y
-  | otherwise = base </> x 
+  | otherwise = base </> x
 
 split s = takeWhile (/="") $ unfoldr (Just . head . lex) $ takeFileName s
 

--- a/04-adding-more-accounts/export/export.hs
+++ b/04-adding-more-accounts/export/export.hs
@@ -99,7 +99,7 @@ main = do
 export_all flags targets = return $ Just $ do
   let first = firstYear flags
       current = currentYear flags
-      
+
   if null targets then want (reports first current) else want targets
 
   -- Discover and cache the list of all includes for the given .journal file, recursively
@@ -109,11 +109,11 @@ export_all flags targets = return $ Just $ do
 
   (transactions "//*") %> hledger_process_year flags year_inputs ["print"]
 
-  (income_expenses "//*") %> hledger_process_year flags year_inputs ["is","--flat"]
+  (income_expenses "//*") %> hledger_process_year flags year_inputs ["is","--flat","--no-elide"]
 
-  (balance_sheet "//*") %> hledger_process_year flags year_inputs ["balancesheet"]
+  (balance_sheet "//*") %> hledger_process_year flags year_inputs ["balancesheet","--no-elide"]
 
-  (cash_flow "//*") %> hledger_process_year flags year_inputs ["cashflow","not:desc:(opening balances)"]
+  (cash_flow "//*") %> hledger_process_year flags year_inputs ["cashflow","not:desc:(opening balances)","--no-elide"]
 
   (closing_balances "//*") %> generate_closing_balances flags year_inputs
 
@@ -192,10 +192,10 @@ getIncludes base file = do
                                                                    , stripPrefix "include " x]]
   return (file:includes)
 
-normalisePath base x  
+normalisePath base x
   | "/" `isPrefixOf` x = x
   | "./export/" `isPrefixOf` x, Just y <- stripPrefix "./export/" x = y
-  | otherwise = base </> x 
+  | otherwise = base </> x
 
 split s = takeWhile (/="") $ unfoldr (Just . head . lex) $ takeFileName s
 

--- a/05-creating-csv-import-rules/export/export.hs
+++ b/05-creating-csv-import-rules/export/export.hs
@@ -103,7 +103,7 @@ main = do
 export_all flags targets = return $ Just $ do
   let first = firstYear flags
       current = currentYear flags
-      
+
   if null targets then want (reports first current) else want targets
 
   -- Discover and cache the list of all includes for the given .journal file, recursively
@@ -115,11 +115,11 @@ export_all flags targets = return $ Just $ do
 
   (accounts "//*") %> hledger_process_year flags year_inputs ["accounts"]
 
-  (income_expenses "//*") %> hledger_process_year flags year_inputs ["is","--flat"]
+  (income_expenses "//*") %> hledger_process_year flags year_inputs ["is","--flat","--no-elide"]
 
-  (balance_sheet "//*") %> hledger_process_year flags year_inputs ["balancesheet"]
+  (balance_sheet "//*") %> hledger_process_year flags year_inputs ["balancesheet","--no-elide"]
 
-  (cash_flow "//*") %> hledger_process_year flags year_inputs ["cashflow","not:desc:(opening balances)"]
+  (cash_flow "//*") %> hledger_process_year flags year_inputs ["cashflow","not:desc:(opening balances)","--no-elide"]
 
   (unknown "//*") %> hledger_process_year flags year_inputs ["print", "unknown"]
 
@@ -200,10 +200,10 @@ getIncludes base file = do
                                                                    , stripPrefix "include " x]]
   return (file:includes)
 
-normalisePath base x  
+normalisePath base x
   | "/" `isPrefixOf` x = x
   | "./export/" `isPrefixOf` x, Just y <- stripPrefix "./export/" x = y
-  | otherwise = base </> x 
+  | otherwise = base </> x
 
 split s = takeWhile (/="") $ unfoldr (Just . head . lex) $ takeFileName s
 

--- a/06-maintaining-lots-of-csv-rules/export/export.hs
+++ b/06-maintaining-lots-of-csv-rules/export/export.hs
@@ -103,7 +103,7 @@ main = do
 export_all flags targets = return $ Just $ do
   let first = firstYear flags
       current = currentYear flags
-      
+
   if null targets then want (reports first current) else want targets
 
   -- Discover and cache the list of all includes for the given .journal file, recursively
@@ -115,11 +115,11 @@ export_all flags targets = return $ Just $ do
 
   (accounts "//*") %> hledger_process_year flags year_inputs ["accounts"]
 
-  (income_expenses "//*") %> hledger_process_year flags year_inputs ["is","--flat"]
+  (income_expenses "//*") %> hledger_process_year flags year_inputs ["is","--flat","--no-elide"]
 
-  (balance_sheet "//*") %> hledger_process_year flags year_inputs ["balancesheet"]
+  (balance_sheet "//*") %> hledger_process_year flags year_inputs ["balancesheet","--no-elide"]
 
-  (cash_flow "//*") %> hledger_process_year flags year_inputs ["cashflow","not:desc:(opening balances)"]
+  (cash_flow "//*") %> hledger_process_year flags year_inputs ["cashflow","not:desc:(opening balances)","--no-elide"]
 
   (unknown "//*") %> hledger_process_year flags year_inputs ["print", "unknown"]
 
@@ -209,10 +209,10 @@ getIncludes base file = do
                                                                    , stripPrefix "include " x]]
   return (file:includes)
 
-normalisePath base x  
+normalisePath base x
   | "/" `isPrefixOf` x = x
   | "./export/" `isPrefixOf` x, Just y <- stripPrefix "./export/" x = y
-  | otherwise = base </> x 
+  | otherwise = base </> x
 
 split s = takeWhile (/="") $ unfoldr (Just . head . lex) $ takeFileName s
 

--- a/07-investments-easy-approach/export/export.hs
+++ b/07-investments-easy-approach/export/export.hs
@@ -110,7 +110,7 @@ main = do
 export_all flags targets = return $ Just $ do
   let first = firstYear flags
       current = currentYear flags
-      
+
   if null targets then want (reports first current) else want targets
 
   -- Discover and cache the list of all includes for the given .journal file, recursively
@@ -122,11 +122,11 @@ export_all flags targets = return $ Just $ do
 
   (accounts "//*") %> hledger_process_year flags year_inputs ["accounts"]
 
-  (income_expenses "//*") %> hledger_process_year flags year_inputs ["is","--flat"]
+  (income_expenses "//*") %> hledger_process_year flags year_inputs ["is","--flat","--no-elide"]
 
-  (balance_sheet "//*") %> hledger_process_year flags year_inputs ["balancesheet"]
+  (balance_sheet "//*") %> hledger_process_year flags year_inputs ["balancesheet","--no-elide"]
 
-  (cash_flow "//*") %> hledger_process_year flags year_inputs ["cashflow","not:desc:(opening balances)"]
+  (cash_flow "//*") %> hledger_process_year flags year_inputs ["cashflow","not:desc:(opening balances)","--no-elide"]
 
   (unknown "//*") %> hledger_process_year flags year_inputs ["print", "unknown"]
 
@@ -144,7 +144,7 @@ export_all flags targets = return $ Just $ do
   "//import//generated.rules" %> generated_rules
 
   ("//" ++ investments) %> generate_investments_report current year_inputs
-  
+
 -------------------------------------
 -- Implementations of the build rules
 -------------------------------------
@@ -210,7 +210,7 @@ generate_investments_report current year_inputs out = do
   deps <- mapM (year_inputs . show) (investment_years current)
   need (concat deps)
   need [ "./investments.sh" ]
-  (Stdout output) <- cmd "./investments.sh" 
+  (Stdout output) <- cmd "./investments.sh"
   writeFileChanged out output
 
 -------------------
@@ -225,10 +225,10 @@ getIncludes base file = do
                                                                    , stripPrefix "include " x]]
   return (file:includes)
 
-normalisePath base x  
+normalisePath base x
   | "/" `isPrefixOf` x = x
   | "./export/" `isPrefixOf` x, Just y <- stripPrefix "./export/" x = y
-  | otherwise = base </> x 
+  | otherwise = base </> x
 
 split s = takeWhile (/="") $ unfoldr (Just . head . lex) $ takeFileName s
 

--- a/08-mortgage/export/export.hs
+++ b/08-mortgage/export/export.hs
@@ -112,7 +112,7 @@ main = do
 export_all flags targets = return $ Just $ do
   let first = firstYear flags
       current = currentYear flags
-      
+
   if null targets then want (reports first current) else want targets
 
   -- Discover and cache the list of all includes for the given .journal file, recursively
@@ -124,11 +124,11 @@ export_all flags targets = return $ Just $ do
 
   (accounts "//*") %> hledger_process_year flags year_inputs ["accounts"]
 
-  (income_expenses "//*") %> hledger_process_year flags year_inputs ["is","--flat"]
+  (income_expenses "//*") %> hledger_process_year flags year_inputs ["is","--flat","--no-elide"]
 
-  (balance_sheet "//*") %> hledger_process_year flags year_inputs ["balancesheet"]
+  (balance_sheet "//*") %> hledger_process_year flags year_inputs ["balancesheet","--no-elide"]
 
-  (cash_flow "//*") %> hledger_process_year flags year_inputs ["cashflow","not:desc:(opening balances)"]
+  (cash_flow "//*") %> hledger_process_year flags year_inputs ["cashflow","not:desc:(opening balances)","--no-elide"]
 
   (unknown "//*") %> hledger_process_year flags year_inputs ["print", "unknown"]
 
@@ -146,7 +146,7 @@ export_all flags targets = return $ Just $ do
   "//import//generated.rules" %> generated_rules
 
   ("//" ++ investments) %> generate_investments_report current year_inputs
-  
+
   -- Mortgage interest transactions
   mortgage_interest "//*" %> generate_mortgage_interest year_inputs
 
@@ -215,7 +215,7 @@ generate_investments_report current year_inputs out = do
   deps <- mapM (year_inputs . show) (investment_years current)
   need (concat deps)
   need [ "./investments.sh" ]
-  (Stdout output) <- cmd "./investments.sh" 
+  (Stdout output) <- cmd "./investments.sh"
   writeFileChanged out output
 
 generate_mortgage_interest year_inputs out = do
@@ -244,10 +244,10 @@ getIncludes base file = do
                                                                    , stripPrefix "include " x]]
   return (file:includes)
 
-normalisePath base x  
+normalisePath base x
   | "/" `isPrefixOf` x = x
   | "./export/" `isPrefixOf` x, Just y <- stripPrefix "./export/" x = y
-  | otherwise = base </> x 
+  | otherwise = base </> x
 
 split s = takeWhile (/="") $ unfoldr (Just . head . lex) $ takeFileName s
 

--- a/09-remortgage/export/export.hs
+++ b/09-remortgage/export/export.hs
@@ -112,7 +112,7 @@ main = do
 export_all flags targets = return $ Just $ do
   let first = firstYear flags
       current = currentYear flags
-      
+
   if null targets then want (reports first current) else want targets
 
   -- Discover and cache the list of all includes for the given .journal file, recursively
@@ -124,11 +124,11 @@ export_all flags targets = return $ Just $ do
 
   (accounts "//*") %> hledger_process_year flags year_inputs ["accounts"]
 
-  (income_expenses "//*") %> hledger_process_year flags year_inputs ["is","--flat"]
+  (income_expenses "//*") %> hledger_process_year flags year_inputs ["is","--flat","--no-elide"]
 
-  (balance_sheet "//*") %> hledger_process_year flags year_inputs ["balancesheet"]
+  (balance_sheet "//*") %> hledger_process_year flags year_inputs ["balancesheet","--no-elide"]
 
-  (cash_flow "//*") %> hledger_process_year flags year_inputs ["cashflow","not:desc:(opening balances)"]
+  (cash_flow "//*") %> hledger_process_year flags year_inputs ["cashflow","not:desc:(opening balances)","--no-elide"]
 
   (unknown "//*") %> hledger_process_year flags year_inputs ["print", "unknown"]
 
@@ -146,7 +146,7 @@ export_all flags targets = return $ Just $ do
   "//import//generated.rules" %> generated_rules
 
   ("//" ++ investments) %> generate_investments_report current year_inputs
-  
+
   -- Mortgage interest transactions
   mortgage_interest "//*" %> generate_mortgage_interest year_inputs
 
@@ -215,7 +215,7 @@ generate_investments_report current year_inputs out = do
   deps <- mapM (year_inputs . show) (investment_years current)
   need (concat deps)
   need [ "./investments.sh" ]
-  (Stdout output) <- cmd "./investments.sh" 
+  (Stdout output) <- cmd "./investments.sh"
   writeFileChanged out output
 
 generate_mortgage_interest year_inputs out = do
@@ -244,10 +244,10 @@ getIncludes base file = do
                                                                    , stripPrefix "include " x]]
   return (file:includes)
 
-normalisePath base x  
+normalisePath base x
   | "/" `isPrefixOf` x = x
   | "./export/" `isPrefixOf` x, Just y <- stripPrefix "./export/" x = y
-  | otherwise = base </> x 
+  | otherwise = base </> x
 
 split s = takeWhile (/="") $ unfoldr (Just . head . lex) $ takeFileName s
 

--- a/10-foreign-currency/export/export.hs
+++ b/10-foreign-currency/export/export.hs
@@ -112,7 +112,7 @@ main = do
 export_all flags targets = return $ Just $ do
   let first = firstYear flags
       current = currentYear flags
-      
+
   if null targets then want (reports first current) else want targets
 
   -- Discover and cache the list of all includes for the given .journal file, recursively
@@ -124,11 +124,11 @@ export_all flags targets = return $ Just $ do
 
   (accounts "//*") %> hledger_process_year flags year_inputs ["accounts"]
 
-  (income_expenses "//*") %> hledger_process_year flags year_inputs ["is","--flat","--cost"]
+  (income_expenses "//*") %> hledger_process_year flags year_inputs ["is","--flat","--no-elide","--cost"]
 
-  (balance_sheet "//*") %> hledger_process_year flags year_inputs ["balancesheet"]
+  (balance_sheet "//*") %> hledger_process_year flags year_inputs ["balancesheet","--no-elide"]
 
-  (cash_flow "//*") %> hledger_process_year flags year_inputs ["cashflow","not:desc:(opening balances)"]
+  (cash_flow "//*") %> hledger_process_year flags year_inputs ["cashflow","not:desc:(opening balances)","--no-elide"]
 
   (unknown "//*") %> hledger_process_year flags year_inputs ["print", "unknown"]
 
@@ -146,7 +146,7 @@ export_all flags targets = return $ Just $ do
   "//import//generated.rules" %> generated_rules
 
   ("//" ++ investments) %> generate_investments_report current year_inputs
-  
+
   -- Mortgage interest transactions
   mortgage_interest "//*" %> generate_mortgage_interest year_inputs
 
@@ -215,7 +215,7 @@ generate_investments_report current year_inputs out = do
   deps <- mapM (year_inputs . show) (investment_years current)
   need (concat deps)
   need [ "./investments.sh" ]
-  (Stdout output) <- cmd "./investments.sh" 
+  (Stdout output) <- cmd "./investments.sh"
   writeFileChanged out output
 
 generate_mortgage_interest year_inputs out = do
@@ -244,10 +244,10 @@ getIncludes base file = do
                                                                    , stripPrefix "include " x]]
   return (file:includes)
 
-normalisePath base x  
+normalisePath base x
   | "/" `isPrefixOf` x = x
   | "./export/" `isPrefixOf` x, Just y <- stripPrefix "./export/" x = y
-  | otherwise = base </> x 
+  | otherwise = base </> x
 
 split s = takeWhile (/="") $ unfoldr (Just . head . lex) $ takeFileName s
 

--- a/11-sorting-unknowns/export/export.hs
+++ b/11-sorting-unknowns/export/export.hs
@@ -112,7 +112,7 @@ main = do
 export_all flags targets = return $ Just $ do
   let first = firstYear flags
       current = currentYear flags
-      
+
   if null targets then want (reports first current) else want targets
 
   -- Discover and cache the list of all includes for the given .journal file, recursively
@@ -124,11 +124,11 @@ export_all flags targets = return $ Just $ do
 
   (accounts "//*") %> hledger_process_year flags year_inputs ["accounts"]
 
-  (income_expenses "//*") %> hledger_process_year flags year_inputs ["is","--flat","--cost"]
+  (income_expenses "//*") %> hledger_process_year flags year_inputs ["is","--flat","--no-elide","--cost"]
 
-  (balance_sheet "//*") %> hledger_process_year flags year_inputs ["balancesheet"]
+  (balance_sheet "//*") %> hledger_process_year flags year_inputs ["balancesheet","--no-elide"]
 
-  (cash_flow "//*") %> hledger_process_year flags year_inputs ["cashflow","not:desc:(opening balances)"]
+  (cash_flow "//*") %> hledger_process_year flags year_inputs ["cashflow","not:desc:(opening balances)","--no-elide"]
 
   (unknown "//*") %> hledger_process_year flags year_inputs ["print", "unknown"]
 
@@ -146,7 +146,7 @@ export_all flags targets = return $ Just $ do
   "//import//generated.rules" %> generated_rules
 
   ("//" ++ investments) %> generate_investments_report current year_inputs
-  
+
   -- Mortgage interest transactions
   mortgage_interest "//*" %> generate_mortgage_interest year_inputs
 
@@ -215,7 +215,7 @@ generate_investments_report current year_inputs out = do
   deps <- mapM (year_inputs . show) (investment_years current)
   need (concat deps)
   need [ "./investments.sh" ]
-  (Stdout output) <- cmd "./investments.sh" 
+  (Stdout output) <- cmd "./investments.sh"
   writeFileChanged out output
 
 generate_mortgage_interest year_inputs out = do
@@ -244,10 +244,10 @@ getIncludes base file = do
                                                                    , stripPrefix "include " x]]
   return (file:includes)
 
-normalisePath base x  
+normalisePath base x
   | "/" `isPrefixOf` x = x
   | "./export/" `isPrefixOf` x, Just y <- stripPrefix "./export/" x = y
-  | otherwise = base </> x 
+  | otherwise = base </> x
 
 split s = takeWhile (/="") $ unfoldr (Just . head . lex) $ takeFileName s
 

--- a/12-file-specific-rules/export/export.hs
+++ b/12-file-specific-rules/export/export.hs
@@ -115,7 +115,7 @@ main = do
 export_all flags targets = return $ Just $ do
   let first = firstYear flags
       current = currentYear flags
-      
+
   if null targets then want (reports first current) else want targets
 
   -- Discover and cache the list of all includes for the given .journal file, recursively
@@ -127,11 +127,11 @@ export_all flags targets = return $ Just $ do
 
   (accounts "//*") %> hledger_process_year flags year_inputs ["accounts"]
 
-  (income_expenses "//*") %> hledger_process_year flags year_inputs ["is","--flat","--cost"]
+  (income_expenses "//*") %> hledger_process_year flags year_inputs ["is","--flat","--no-elide","--cost"]
 
-  (balance_sheet "//*") %> hledger_process_year flags year_inputs ["balancesheet"]
+  (balance_sheet "//*") %> hledger_process_year flags year_inputs ["balancesheet","--no-elide"]
 
-  (cash_flow "//*") %> hledger_process_year flags year_inputs ["cashflow","not:desc:(opening balances)"]
+  (cash_flow "//*") %> hledger_process_year flags year_inputs ["cashflow","not:desc:(opening balances)","--no-elide"]
 
   (unknown "//*") %> hledger_process_year flags year_inputs ["print", "unknown"]
 
@@ -149,7 +149,7 @@ export_all flags targets = return $ Just $ do
   "//import//generated.rules" %> generated_rules
 
   ("//" ++ investments) %> generate_investments_report current year_inputs
-  
+
   -- Mortgage interest transactions
   mortgage_interest "//*" %> generate_mortgage_interest year_inputs
 
@@ -218,7 +218,7 @@ generate_investments_report current year_inputs out = do
   deps <- mapM (year_inputs . show) (investment_years current)
   need (concat deps)
   need [ "./investments.sh" ]
-  (Stdout output) <- cmd "./investments.sh" 
+  (Stdout output) <- cmd "./investments.sh"
   writeFileChanged out output
 
 generate_mortgage_interest year_inputs out = do
@@ -247,10 +247,10 @@ getIncludes base file = do
                                                                    , stripPrefix "include " x]]
   return (file:includes)
 
-normalisePath base x  
+normalisePath base x
   | "/" `isPrefixOf` x = x
   | "./export/" `isPrefixOf` x, Just y <- stripPrefix "./export/" x = y
-  | otherwise = base </> x 
+  | otherwise = base </> x
 
 split s = takeWhile (/="") $ unfoldr (Just . head . lex) $ takeFileName s
 


### PR DESCRIPTION
It seems that, since [`hledger 1.19`][hledger_commit], report lines with multiple commodities are elided by default. This is the difference between having a total row displaying `USD 1,000.00, 2 more..`, and having the totals for all the different commodities displayed in the generated report.

With this change, reports now display all commodities.

[hledger_commit]: https://github.com/simonmichael/hledger/commit/2739a70a38b28114d9ab042cdf3597f53337dc02