### PR TITLE
Reduce Docker image size by removing Pantry cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ COPY ./01-getting-started/export/export.hs /tmp
 # Precompile all packages needed for export.hs
 RUN stack --resolver $RESOLVER --system-ghc script --package shake --package directory /tmp/export.hs -- -v \
     && rm -r /tmp/export.* \
+    && rm -rf /root/.stack/pantry \
     && chmod -R g+wrX,o+wrX /root \
     && apt-get update \
     && apt-get install --yes patchutils gawk csvtool ripgrep parallel \


### PR DESCRIPTION
Using [dive](https://github.com/wagoodman/dive), I found that almost half the size of the Docker image is actually the Pantry cache. By removing the Pantry folder, the image size goes from 3.3GiB to 1.8GiB!

```
REPOSITORY              TAG        IMAGE ID        CREATED       SIZE
full-fledged-hledger    patched    90b49ff7942a    1 hour ago    1.82GB
full-fledged-hledger    master     b3e8bcb92ac8    1 hour ago    3.28GB
```

I'm not completely familiar with the Haskell toolchain, but if I understand correctly, removing this folder is harmless, and shouldn't affect the main purpose of the Docker image, which is just to run `hledger*` commands.